### PR TITLE
[FIXED] A crash that was regressed due to changes in PR 73

### DIFF
--- a/app/src/main/java/com/hossainkhan/android/demo/layoutpreview/LayoutPreviewBaseActivity.kt
+++ b/app/src/main/java/com/hossainkhan/android/demo/layoutpreview/LayoutPreviewBaseActivity.kt
@@ -162,7 +162,7 @@ open class LayoutPreviewBaseActivity : AppCompatActivity() {
         builder.setShowTitle(false)
                 .addDefaultShareMenuItem()
         val customTabsIntent = builder.build()
-        customTabsIntent.launchUrl(applicationContext, Uri.parse(viewModel.layoutUrl))
+        customTabsIntent.launchUrl(this, Uri.parse(viewModel.layoutUrl))
     }
 
 

--- a/app/src/main/res/layout/preview_virtual_helper_group.xml
+++ b/app/src/main/res/layout/preview_virtual_helper_group.xml
@@ -24,7 +24,8 @@
     android:layout_margin="16dp"
     android:animateLayoutChanges="true">
 
-    <!-- This virtual helper has `constraint_referenced_ids` to multiple views to apply visibility to all of them  -->
+    <!-- This virtual helper has `constraint_referenced_ids` to
+    multiple views to apply visibility to all of them  -->
     <androidx.constraintlayout.widget.Group
         android:id="@+id/visual_group"
         android:layout_width="wrap_content"


### PR DESCRIPTION
https://github.com/amardeshbd/android-constraint-layout-cheatsheet/pull/73 for #69

```
2019-04-06 11:49:15.514 20635-20635/com.hossainkhan.android.constraintlayout E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.hossainkhan.android.constraintlayout, PID: 20635
    android.util.AndroidRuntimeException: Calling startActivity() from outside of an Activity  context requires the FLAG_ACTIVITY_NEW_TASK flag. Is this really what you want?
        at android.app.ContextImpl.startActivity(ContextImpl.java:912)
        at android.content.ContextWrapper.startActivity(ContextWrapper.java:401)
        at androidx.core.content.ContextCompat.startActivity(ContextCompat.java:248)
        at androidx.browser.customtabs.CustomTabsIntent.launchUrl(CustomTabsIntent.java:263)
        at com.hossainkhan.android.demo.layoutpreview.LayoutPreviewBaseActivity.loadLayoutUrl(LayoutPreviewBaseActivity.kt:165)
        at com.hossainkhan.android.demo.layoutpreview.LayoutPreviewBaseActivity$showLayoutInfo$1.onActionTapped(LayoutPreviewBaseActivity.kt:135)
        at com.andrognito.flashbar.FlashbarView$setPositiveActionTapListener$1.onClick(FlashbarView.kt:329)
        at android.view.View.performClick(View.java:6597)
        at android.view.View.performClickInternal(View.java:6574)
        at android.view.View.access$3100(View.java:778)
        at android.view.View$PerformClick.run(View.java:25885)
        at android.os.Handler.handleCallback(Handler.java:873)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loop(Looper.java:193)
```