### PR TITLE
[FIXED] [#69] Memory leak for the dialog.

### DIFF
--- a/app/src/main/java/com/hossainkhan/android/demo/ui/dialog/LayoutInfoDialog.kt
+++ b/app/src/main/java/com/hossainkhan/android/demo/ui/dialog/LayoutInfoDialog.kt
@@ -16,17 +16,20 @@
 
 package com.hossainkhan.android.demo.ui.dialog
 
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.TextView
+import androidx.browser.customtabs.CustomTabsIntent
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.google.android.material.button.MaterialButton
 import com.hossainkhan.android.demo.R
+import timber.log.Timber
 
 
 /**
@@ -36,11 +39,13 @@ class LayoutInfoDialog : BottomSheetDialogFragment() {
     companion object {
         private const val BUNDLE_ARG_KEY_TITLE = "BUNDLE_TITLE"
         private const val BUNDLE_ARG_KEY_DESC = "BUNDLE_DESCRIPTION"
+        private const val BUNDLE_ARG_KEY_LAYOUT_URL = "BUNDLE_LAYOUT_URL"
 
-        fun newInstance(title: String, description: String): LayoutInfoDialog {
+        fun newInstance(title: String, description: String, layoutUrl: String): LayoutInfoDialog {
             val args = Bundle()
             args.putString(BUNDLE_ARG_KEY_TITLE, title)
             args.putString(BUNDLE_ARG_KEY_DESC, description)
+            args.putString(BUNDLE_ARG_KEY_LAYOUT_URL, layoutUrl)
 
             val dialog = LayoutInfoDialog()
 
@@ -55,7 +60,6 @@ class LayoutInfoDialog : BottomSheetDialogFragment() {
     lateinit var infoDescription: TextView
     lateinit var okButton: MaterialButton
     lateinit var previewXml: MaterialButton
-    var previewXmlListener: (() -> Unit)? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         val view = inflater.inflate(R.layout.dialog_layout_info_sheet, container, false)
@@ -83,6 +87,7 @@ class LayoutInfoDialog : BottomSheetDialogFragment() {
                 arguments!!.getString(BUNDLE_ARG_KEY_TITLE, ""),
                 arguments!!.getString(BUNDLE_ARG_KEY_DESC, "")
         )
+
     }
 
     override fun onPause() {
@@ -98,7 +103,19 @@ class LayoutInfoDialog : BottomSheetDialogFragment() {
         okButton.setOnClickListener { dismiss() }
         previewXml.setOnClickListener {
             dismiss()
-            previewXmlListener?.invoke()
+            loadLayoutUrl(arguments!!.getString(BUNDLE_ARG_KEY_LAYOUT_URL, null))
         }
+    }
+
+    /**
+     * Loads currently running layout from Github into chrome web view.
+     */
+    fun loadLayoutUrl(url: String) {
+        Timber.d("Showing layout source code via: %s", url)
+        val builder = CustomTabsIntent.Builder()
+        builder.setShowTitle(false)
+                .addDefaultShareMenuItem()
+        val customTabsIntent = builder.build()
+        customTabsIntent.launchUrl(context, Uri.parse(url))
     }
 }

--- a/app/src/main/java/com/hossainkhan/android/demo/ui/layoutpreview/LayoutPreviewBaseActivity.kt
+++ b/app/src/main/java/com/hossainkhan/android/demo/ui/layoutpreview/LayoutPreviewBaseActivity.kt
@@ -112,13 +112,15 @@ open class LayoutPreviewBaseActivity : AppCompatActivity() {
      * Loads layout information and previews in a snackbar.
      */
     private fun showLayoutInfo(layoutInformation: LayoutInformation, fromUser: Boolean = false) {
-        infoDialog = LayoutInfoDialog.newInstance(
-                layoutInformation.title.toString(),
-                layoutInformation.description.toString()
-        )
-        infoDialog?.previewXmlListener = { loadLayoutUrl() }
+        if (infoDialog == null) {
+            infoDialog = LayoutInfoDialog.newInstance(
+                    layoutInformation.title.toString(),
+                    layoutInformation.description.toString(),
+                    viewModel.layoutUrl
+            )
+        }
 
-        Timber.d("Layout info showing: %s", infoDialog?.isVisible)
+        Timber.d("Layout info is showing: %s", infoDialog?.isVisible)
         if (infoDialog?.isVisible == false) {
             if (fromUser || viewModel.isFirstTime) {
                 infoDialog?.let {
@@ -130,17 +132,11 @@ open class LayoutPreviewBaseActivity : AppCompatActivity() {
         }
     }
 
-    /**
-     * Loads currently running layout from Github into chrome web view.
-     */
-    fun loadLayoutUrl() {
-        val builder = CustomTabsIntent.Builder()
-        builder.setShowTitle(false)
-                .addDefaultShareMenuItem()
-        val customTabsIntent = builder.build()
-        customTabsIntent.launchUrl(this, Uri.parse(viewModel.layoutUrl))
+    override fun onStop() {
+        super.onStop()
+        Timber.d("Clearing the layout info dialog.")
+        infoDialog = null
     }
-
 
     //
     // Setup menu item on the action bar.


### PR DESCRIPTION
Now the dialog is created only once, and cleared on destroy. Also, there is no listener needed.

Fixes #69 

For now, closing the issue as the root cause is hard to find. Applied some optimization so that the dialog does not have access to anything related to activity. And whenever activity is destroyed, the dialog is also cleared.