### PR TITLE
[FIXED] Gradle warning API 'variant.getExternalNativeBuildTasks()' is…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ buildscript {
      * Fabric/Firebase gradle tools version.
      * https://firebase.google.com/docs/crashlytics/
      */
-    ext.fabricGradleToolsVersion = '1.25.4'
+    ext.fabricGradleToolsVersion = '1.29.0'
 
     /*
      * Google play services plugin


### PR DESCRIPTION
… obsolete and has been replaced with 'variant.getExternalNativeBuildProviders() - Ref: https://stackoverflow.com/questions/52412023/api-variant-getexternalnativebuildtasks-is-obsolete-and-has-been-replaced-wi